### PR TITLE
Explicitly add lmorandomizer bin crate to cargo for Tauri

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["you"]
 edition = "2021"
 
 [[bin]]
+name = "lmorandomizer"
+path = "src/main.rs"
+
+[[bin]]
 name = "lmocodec"
 path = "src/codec.rs"
 


### PR DESCRIPTION
The introduction of `lmocodec` broke application bundling via Tauri.

On MacOS, we can see this due to the generated plist:

```
❯ cat Info.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>CFBundleDevelopmentRegion</key>
	<string>English</string>
	<key>CFBundleDisplayName</key>
	<string>lmorandomizer</string>
	<key>CFBundleExecutable</key>
	<string>lmocodec</string>
...
```
This appears to be undocumented(?) behavior in Tauri, but by adding a binary to our cargo.toml matching our tauri application name, it appears to successfully pick up both binaries, and correctly link the bundle.

Prior to this change, the generated .app bundle on MacOS only contains the `lmocodec` binary, and I have a similar report from a friend on Windows.