### PR TITLE
pippols rom requires lamp to reach.

### DIFF
--- a/src-tauri/res/14_Tower_of_the_Goddess.yml
+++ b/src-tauri/res/14_Tower_of_the_Goddess.yml
@@ -16,4 +16,4 @@ roms:
   unreleasedRom:
     - event:reachedBackDoorOfGateOfIllusion, msx2, qBert, divinerSensation
   pippols:
-    - event:reachedLowerOfChamberOfBirth
+    - event:reachedLowerOfChamberOfBirth, lampOfTime


### PR DESCRIPTION
v0.8.0

seed: 69420BRUH

TowerOfTheGoddess_RomSpot(pippols) = lampOfTime, which is an impossible placement

