### PR TITLE
Fix macos cache key collision.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,16 @@ jobs:
         include:
           - platform: 'macos-latest'
             args: '--target aarch64-apple-darwin'
+            cache_key: 'aarch64'
           - platform: 'macos-latest'
             args: '--target x86_64-apple-darwin'
+            cache_key: 'x86_84'
           - platform: 'ubuntu-22.04'
             args: ''
+            cache_key: ''
           - platform: 'windows-latest'
             args: ''
+            cache_key: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -33,7 +37,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             src-tauri/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.cache_key }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -14,6 +14,7 @@ jobs:
         include:
           - platform: 'ubuntu-22.04'
             args: ''
+            cache_key: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -26,7 +27,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             src-tauri/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.cache_key }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: setup node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Noticed this too late, sorry!

Since the aarch64 and x86_64 split is handled as a target for cargo, rather than runner.os, I need an extra way to differentiate the cache keys.

Old runner caches will autoexpire, so we don't need to worry about any cleanup.