### PR TITLE
feat(randomizer): sphere 内アイテム選択を条件付き一様な棄却サンプリングに変更

### DIFF
--- a/src-tauri/src/dataset/files.rs
+++ b/src-tauri/src/dataset/files.rs
@@ -60,15 +60,23 @@ pub struct Exits {
 }
 
 impl Exits {
-    pub fn all_exits(&self) -> impl Iterator<Item = (&RegionName, &FieldYamlAccessRule)> {
-        self.up
-            .iter()
-            .chain(self.down.iter())
-            .chain(self.left.iter())
-            .chain(self.right.iter())
-            .chain(self.door.iter())
-            .chain(self.warp.iter())
-            .chain(self.fixed.iter())
+    pub fn into_all_exits(
+        self,
+    ) -> impl Iterator<Item = (&'static str, RegionName, FieldYamlAccessRule)> {
+        [
+            ("up", self.up),
+            ("down", self.down),
+            ("left", self.left),
+            ("right", self.right),
+            ("door", self.door),
+            ("warp", self.warp),
+            ("fixed", self.fixed),
+        ]
+        .into_iter()
+        .flat_map(|(direction, map)| {
+            map.into_iter()
+                .map(move |(name, access_rule)| (direction, name, access_rule))
+        })
     }
 }
 

--- a/src-tauri/src/dataset/game_structure.rs
+++ b/src-tauri/src/dataset/game_structure.rs
@@ -11,7 +11,7 @@ use vec1::Vec1;
 use crate::{
     dataset::{
         files::{EventsYaml, FieldYaml, FieldYamlAccessRule},
-        spot::{Region, SpotName},
+        spot::{Region, RegionExit, SpotName},
     },
     script::enums::{
         ChestItem, Equipment, FieldNumber, MainWeapon, Rom, Seal, ShopItem, SubWeapon, TalkItem,
@@ -90,13 +90,24 @@ impl GameStructure {
         let mut regions = vec![];
         for (field_number, field_yaml) in fields {
             for (region_name, field_yaml_region) in field_yaml.0 {
+                let exits = field_yaml_region
+                    .exits
+                    .into_all_exits()
+                    .map(|(direction, target, access_rule)| {
+                        Ok(RegionExit {
+                            direction,
+                            target,
+                            requirements: access_rule.try_into_any_of_all_requirements()?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
                 let region = Region::new(
                     field_number,
                     region_name,
                     field_yaml_region
                         .access_rule
                         .try_into_any_of_all_requirements()?,
-                    field_yaml_region.exits,
+                    exits,
                 );
                 for (item, access_rule) in field_yaml_region.main_weapons {
                     let location = main_weapon_location(region.clone(), item, access_rule)?;
@@ -152,42 +163,31 @@ fn validate_exits(regions: &[super::spot::Region]) {
     let exits_to: BTreeMap<&RegionName, BTreeSet<&RegionName>> = regions
         .iter()
         .map(|r| {
-            let targets: BTreeSet<_> = r.exits().all_exits().map(|(name, _)| name).collect();
+            let targets: BTreeSet<_> = r.exits().iter().map(|exit| &exit.target).collect();
             (r.name(), targets)
         })
         .collect();
 
     for region in regions {
-        let exits = region.exits();
-        let directions = [
-            ("up", &exits.up),
-            ("down", &exits.down),
-            ("left", &exits.left),
-            ("right", &exits.right),
-            ("door", &exits.door),
-            ("warp", &exits.warp),
-            ("fixed", &exits.fixed),
-        ];
-        for (dir, map) in directions {
-            for target_name in map.keys() {
-                if !all_region_names.contains(target_name) {
-                    trace!(
-                        "[validate] exit target not found: {} -({})-> {}",
-                        region.name().get(),
-                        dir,
-                        target_name.get()
-                    );
-                    continue;
-                }
-                let target_exits = &exits_to[target_name];
-                if !target_exits.contains(region.name()) {
-                    trace!(
-                        "[validate] no return exit: {} -({})-> {} (no exit back)",
-                        region.name().get(),
-                        dir,
-                        target_name.get()
-                    );
-                }
+        for exit in region.exits() {
+            let (dir, target_name) = (exit.direction, &exit.target);
+            if !all_region_names.contains(target_name) {
+                trace!(
+                    "[validate] exit target not found: {} -({})-> {}",
+                    region.name().get(),
+                    dir,
+                    target_name.get()
+                );
+                continue;
+            }
+            let target_exits = &exits_to[target_name];
+            if !target_exits.contains(region.name()) {
+                trace!(
+                    "[validate] no return exit: {} -({})-> {} (no exit back)",
+                    region.name().get(),
+                    dir,
+                    target_name.get()
+                );
             }
         }
     }

--- a/src-tauri/src/dataset/spot/mod.rs
+++ b/src-tauri/src/dataset/spot/mod.rs
@@ -10,7 +10,7 @@ mod talk_spot;
 pub use {
     chest_spot::ChestSpot,
     main_weapon_spot::MainWeaponSpot,
-    params::{AllRequirements, AnyOfAllRequirements, Region, RequirementFlag, SpotName},
+    params::{AllRequirements, AnyOfAllRequirements, Region, RegionExit, RequirementFlag, SpotName},
     rom_spot::RomSpot,
     seal_spot::SealSpot,
     shop_spot::ShopSpot,

--- a/src-tauri/src/dataset/spot/params.rs
+++ b/src-tauri/src/dataset/spot/params.rs
@@ -2,17 +2,23 @@ use std::fmt::{self, Display};
 
 use vec1::Vec1;
 
-use crate::{
-    dataset::files::{Exits, RegionName},
-    script::enums::FieldNumber,
-};
+use crate::{dataset::files::RegionName, script::enums::FieldNumber};
+
+/// パース済みの exit。access rule を到達判定のたびにパースしなくて済むよう、
+/// ロード時に一度だけ変換して保持する
+#[derive(Clone, Debug)]
+pub struct RegionExit {
+    pub direction: &'static str,
+    pub target: RegionName,
+    pub requirements: Option<AnyOfAllRequirements>,
+}
 
 #[derive(Clone, Debug)]
 pub struct Region {
     field_number: FieldNumber,
     name: RegionName,
     access_rule: Option<AnyOfAllRequirements>,
-    exits: Exits,
+    exits: Vec<RegionExit>,
 }
 
 impl Region {
@@ -20,7 +26,7 @@ impl Region {
         field_number: FieldNumber,
         name: RegionName,
         access_rule: Option<AnyOfAllRequirements>,
-        exits: Exits,
+        exits: Vec<RegionExit>,
     ) -> Self {
         Self {
             field_number,
@@ -42,7 +48,7 @@ impl Region {
         self.access_rule.as_ref()
     }
 
-    pub fn exits(&self) -> &Exits {
+    pub fn exits(&self) -> &[RegionExit] {
         &self.exits
     }
 }

--- a/src-tauri/src/randomizer/randomize_items.rs
+++ b/src-tauri/src/randomizer/randomize_items.rs
@@ -204,12 +204,12 @@ mod tests {
 
         let shuffled_str = format!("{:?}", shuffled);
         let shuffled_hash = hex::encode(sha3::Sha3_512::digest(shuffled_str));
-        const EXPECTED_SHUFFLED_HASH: &str = "28b0da511119cc31f2b576030aed3be9a35ee227059261a20e693d3bbf89cd5464efc8ef4e69a06682ddf6a1a4c62cf6e39349e5bf41607f46dbdcd41cc8d623";
+        const EXPECTED_SHUFFLED_HASH: &str = "bc1ba5f434b10920bfb2b4bfd49c91f3fa1ace857c49561ce18d96ecf0f8019fe05a041053b925d59dcd1cf9c68f3b530c5a68117fd0acfaa240a98496f3ca74";
         assert_eq!(shuffled_hash, EXPECTED_SHUFFLED_HASH);
 
         let spoiler_log_str = format!("{}", spoiler_log.to_owned());
         let spoiler_log_hash = hex::encode(sha3::Sha3_512::digest(spoiler_log_str));
-        const EXPECTED_SPOILER_LOG_HASH: &str = "5ca98897aed84fe8ce8391267053e2f6a111340e4f701e8e2f4777e64bbd8fb8879440e513e30e46c84e528ccfea3abba49cff584d0a99a221a8535f422ac640";
+        const EXPECTED_SPOILER_LOG_HASH: &str = "e5d81592d5067a313e8b954cd958e60d5de5a0933dc32c3ed8a0fac16a8d246d844963be3537ae28c82c064f591434eee44a1d02700ec7121b055bb973fd7fdc";
         assert_eq!(spoiler_log_hash, EXPECTED_SPOILER_LOG_HASH);
 
         Ok(())

--- a/src-tauri/src/randomizer/randomize_items.rs
+++ b/src-tauri/src/randomizer/randomize_items.rs
@@ -204,7 +204,7 @@ mod tests {
 
         let shuffled_str = format!("{:?}", shuffled);
         let shuffled_hash = hex::encode(sha3::Sha3_512::digest(shuffled_str));
-        const EXPECTED_SHUFFLED_HASH: &str = "bc1ba5f434b10920bfb2b4bfd49c91f3fa1ace857c49561ce18d96ecf0f8019fe05a041053b925d59dcd1cf9c68f3b530c5a68117fd0acfaa240a98496f3ca74";
+        const EXPECTED_SHUFFLED_HASH: &str = "c886bd87797a240f226078ce67c441923eceed620a5c02f606800924dbac92e28240d74f14d958bae4b109974f0bbd6e5106278690ce815a1fdf2cbe51ce6ca4";
         assert_eq!(shuffled_hash, EXPECTED_SHUFFLED_HASH);
 
         let spoiler_log_str = format!("{}", spoiler_log.to_owned());

--- a/src-tauri/src/randomizer/spoiler/items_pool/items.rs
+++ b/src-tauri/src/randomizer/spoiler/items_pool/items.rs
@@ -1,41 +1,13 @@
 use rand::{Rng, seq::SliceRandom};
 
-use crate::randomizer::{spoiler::spots::SpotRef, storage::item::Item};
+use crate::randomizer::storage::item::Item;
 
-pub fn fill_items_from<'a>(
-    dst: &mut UnorderedItems<'a>,
-    target_len: usize,
-    src: &mut ShuffledItems<'a>,
-) {
-    debug_assert!(target_len <= src.len() + dst.len());
-    dst.append_count(src, target_len - dst.len());
-}
-
-pub fn move_one_required_item<'a>(
-    dst: &mut UnorderedItems<'a>,
-    src: &mut ShuffledItems<'a>,
-    spots: &[&SpotRef<'a>],
-) {
-    // let Some(pos) = src
-    //     .0
-    //     .iter()
-    //     .position(|item| spots.iter().any(|spot| spot.is_related_to(item)))
-    let Some(pos) = src.0.iter().position(|item| item.is_required(spots)) else {
-        return;
-    };
-    dst.0.push(src.0.swap_remove(pos));
-}
-
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct UnorderedItems<'a>(Vec<&'a Item>);
 
 impl<'a> UnorderedItems<'a> {
     pub fn new(items: Vec<&'a Item>) -> Self {
         UnorderedItems(items)
-    }
-
-    fn append_count(&mut self, other: &mut ShuffledItems<'a>, cnt: usize) {
-        self.0.append(&mut other.split_off(other.len() - cnt).0);
     }
 
     pub fn into_inner(self) -> Vec<&'a Item> {
@@ -52,10 +24,14 @@ impl<'a> UnorderedItems<'a> {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct ShuffledItems<'a>(Vec<&'a Item>);
 
 impl<'a> ShuffledItems<'a> {
+    pub fn as_slice(&self) -> &[&'a Item] {
+        &self.0
+    }
+
     pub fn into_inner(self) -> Vec<&'a Item> {
         self.0
     }
@@ -71,6 +47,10 @@ impl<'a> ShuffledItems<'a> {
 
     pub fn pop(&mut self) -> Option<&'a Item> {
         self.0.pop()
+    }
+
+    pub fn shuffle(&mut self, rng: &mut impl Rng) {
+        self.0.shuffle(rng);
     }
 
     pub fn split_off(&mut self, at: usize) -> ShuffledItems<'a> {

--- a/src-tauri/src/randomizer/spoiler/items_pool/mod.rs
+++ b/src-tauri/src/randomizer/spoiler/items_pool/mod.rs
@@ -110,10 +110,10 @@ mod tests {
         Item::main_weapon(MainWeapon::Whip, StrategyFlag::new(name.to_owned()))
     }
 
-    fn items_pool<'a>(field_items: Vec<&'a Item>) -> ItemsPool<'a> {
+    fn items_pool<'a>(rng: &mut impl Rng, field_items: Vec<&'a Item>) -> ItemsPool<'a> {
         ItemsPool {
             priority_items: None,
-            field_items: UnorderedItems::new(field_items).shuffle(&mut make_rng("pool")),
+            field_items: UnorderedItems::new(field_items).shuffle(rng),
             talk_items: Default::default(),
             shop_items: Default::default(),
             consumable_items: Default::default(),
@@ -135,7 +135,7 @@ mod tests {
         let mut counts: BTreeMap<String, u32> = BTreeMap::new();
         const TRIALS: u32 = 7000;
         for _ in 0..TRIALS {
-            let mut pool = items_pool(items.iter().collect());
+            let mut pool = items_pool(&mut rng, items.iter().collect());
             let (field, talk, shop) = pool
                 .pick_items_with_retry(&mut rng, 2, 0, 0, is_progression)
                 .unwrap();
@@ -176,7 +176,7 @@ mod tests {
             .map(|name| item(name))
             .collect();
         let mut rng = make_rng("test");
-        let mut pool = items_pool(items.iter().collect());
+        let mut pool = items_pool(&mut rng, items.iter().collect());
         let picked = pool.pick_items_with_retry(&mut rng, 2, 0, 0, |_| false);
         assert_eq!(picked.unwrap().0.len(), 2);
         assert_eq!(pool.field_items.len(), 1);

--- a/src-tauri/src/randomizer/spoiler/items_pool/mod.rs
+++ b/src-tauri/src/randomizer/spoiler/items_pool/mod.rs
@@ -2,22 +2,17 @@ mod items;
 
 use std::mem::take;
 
-use rand::{Rng, RngExt};
+use rand::Rng;
 
-use super::spots::{SpotRef, Spots};
-
-use items::{fill_items_from, move_one_required_item};
+use crate::randomizer::storage::item::Item;
 
 pub use items::{ShuffledItems, UnorderedItems};
 
-fn item_shop_spot_count(spots: &Spots<'_>) -> usize {
-    spots
-        .shops
-        .iter()
-        .map(|shop| (!shop.name.is_consumable()) as usize)
-        .sum::<usize>()
-}
+/// 棄却再抽選の上限。進行候補を引ける状態なら 1 回あたりの成功確率は
+/// 最低でも 1/(pool サイズ) 程度あるため、この回数で失敗することは実質ない。
+const MAX_RETRY_COUNT: usize = 10_000;
 
+#[derive(Clone)]
 pub struct ItemsPool<'a> {
     pub priority_items: Option<UnorderedItems<'a>>,
     pub field_items: ShuffledItems<'a>,
@@ -33,57 +28,157 @@ impl<'a> ItemsPool<'a> {
             .shuffle(rng);
     }
 
-    pub fn pick_items_randomly(
+    /// 通常の一様抽選。呼ぶたびに pool を再シャッフルするため、
+    /// 各呼び出しは独立した一様抽選になる。
+    fn pick_items_randomly(
         &mut self,
         rng: &mut impl Rng,
-        reachables: &Spots<'a>,
-        unreachables: &Spots<'a>,
+        field_count: usize,
+        talk_count: usize,
+        shop_count: usize,
     ) -> (ShuffledItems<'a>, ShuffledItems<'a>, ShuffledItems<'a>) {
-        debug_assert_eq!(
-            self.shop_items.len() + self.consumable_items.len(),
-            reachables.shops.len() + unreachables.shops.len(),
-        );
         debug_assert!(self.priority_items.is_none());
-
-        let shops: Vec<_> = unreachables
-            .shops
-            .iter()
-            .map(|shop| SpotRef::Shop(shop.spot))
-            .collect();
-        // 残っているスポット
-        let remaining_spots: Vec<_> = unreachables
-            .field_item_spots
-            .iter()
-            .chain(shops.iter())
-            .collect();
-        // 必要な通常アイテムの数
-        let req_f_items = reachables.field_item_spots.len();
-        // 必要なトークアイテムの数
-        let req_t_items = reachables.talk_spots.len();
-        // 必要なショップアイテムの数
-        let req_s_items = item_shop_spot_count(reachables);
-
-        let mut field_items = Default::default();
-        let mut shop_items = Default::default();
-        let mut talk_items = Default::default();
-        // 少なくとも一つは行動を広げるアイテムを配置する
-        let dice = rng.random_range(0..(req_f_items + req_t_items + req_s_items));
-        let (dst, src) = match dice {
-            dice if (0..req_f_items).contains(&dice) => (&mut field_items, &mut self.field_items),
-            dice if (req_f_items..(req_f_items + req_t_items)).contains(&dice) => {
-                (&mut talk_items, &mut self.talk_items)
-            }
-            _ => (&mut shop_items, &mut self.shop_items),
-        };
-        move_one_required_item(dst, src, &remaining_spots);
-        fill_items_from(&mut field_items, req_f_items, &mut self.field_items);
-        fill_items_from(&mut talk_items, req_t_items, &mut self.talk_items);
-        fill_items_from(&mut shop_items, req_s_items, &mut self.shop_items);
-
+        self.field_items.shuffle(rng);
+        self.talk_items.shuffle(rng);
+        self.shop_items.shuffle(rng);
         (
-            field_items.shuffle(rng),
-            talk_items.shuffle(rng),
-            shop_items.shuffle(rng),
+            self.field_items
+                .split_off(self.field_items.len() - field_count),
+            self.talk_items
+                .split_off(self.talk_items.len() - talk_count),
+            self.shop_items
+                .split_off(self.shop_items.len() - shop_count),
         )
+    }
+
+    /// 「進行候補を少なくとも1つ含む」集合になるまで一様抽選を繰り返すことで、
+    /// 条件付き一様な抽選を行う。棄却は一時 pool 上で行い、採用時のみ本体へ反映する。
+    ///
+    /// 進行候補をそもそも引けない場合(最終 sphere や、単体では進行しない
+    /// アイテムの組み合わせしか残っていない場合)は、条件なしの一様抽選を返す。
+    pub fn pick_items_with_retry(
+        &mut self,
+        rng: &mut impl Rng,
+        field_count: usize,
+        talk_count: usize,
+        shop_count: usize,
+        is_progression: impl Fn(&Item) -> bool,
+    ) -> Option<(ShuffledItems<'a>, ShuffledItems<'a>, ShuffledItems<'a>)> {
+        let pools = [
+            (field_count, &self.field_items),
+            (talk_count, &self.talk_items),
+            (shop_count, &self.shop_items),
+        ];
+        let pickable = pools.into_iter().any(|(count, pool)| {
+            count > 0 && pool.as_slice().iter().any(|item| is_progression(item))
+        });
+        if !pickable {
+            return Some(self.pick_items_randomly(rng, field_count, talk_count, shop_count));
+        }
+        for _ in 0..MAX_RETRY_COUNT {
+            let mut candidate_pool = self.clone();
+            let picked =
+                candidate_pool.pick_items_randomly(rng, field_count, talk_count, shop_count);
+            let contains_progression = [&picked.0, &picked.1, &picked.2]
+                .into_iter()
+                .flat_map(|items| items.as_slice())
+                .any(|item| is_progression(item));
+            if contains_progression {
+                *self = candidate_pool;
+                return Some(picked);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{
+        randomizer::{
+            spoiler::make_rng,
+            storage::item::{Item, StrategyFlag},
+        },
+        script::enums::MainWeapon,
+    };
+
+    use super::*;
+
+    fn item(name: &str) -> Item {
+        Item::main_weapon(MainWeapon::Whip, StrategyFlag::new(name.to_owned()))
+    }
+
+    fn items_pool<'a>(field_items: Vec<&'a Item>) -> ItemsPool<'a> {
+        ItemsPool {
+            priority_items: None,
+            field_items: UnorderedItems::new(field_items).shuffle(&mut make_rng("pool")),
+            talk_items: Default::default(),
+            shop_items: Default::default(),
+            consumable_items: Default::default(),
+        }
+    }
+
+    /// 進行候補 A, B と非進行候補 x, y, z から2個選ぶとき、
+    /// 「進行候補を少なくとも1つ含む」7通りが概ね同じ頻度になること。
+    /// 旧方式(進行候補を1つ先に投入)では AB が過大になる。
+    #[test]
+    fn test_pick_items_with_retry_is_conditionally_uniform() {
+        let items: Vec<_> = ["objA", "objB", "objX", "objY", "objZ"]
+            .iter()
+            .map(|name| item(name))
+            .collect();
+        let is_progression = |item: &Item| matches!(item.name.get(), "objA" | "objB");
+
+        let mut rng = make_rng("test");
+        let mut counts: BTreeMap<String, u32> = BTreeMap::new();
+        const TRIALS: u32 = 7000;
+        for _ in 0..TRIALS {
+            let mut pool = items_pool(items.iter().collect());
+            let (field, talk, shop) = pool
+                .pick_items_with_retry(&mut rng, 2, 0, 0, is_progression)
+                .unwrap();
+            assert_eq!(field.len(), 2);
+            assert_eq!(talk.len(), 0);
+            assert_eq!(shop.len(), 0);
+            assert_eq!(pool.field_items.len(), 3);
+            let mut names: Vec<_> = field.as_slice().iter().map(|x| x.name.get()).collect();
+            names.sort();
+            *counts.entry(names.join("+")).or_default() += 1;
+        }
+
+        // 進行候補を含まない組み合わせ(xy, xz, yz)は棄却されている
+        assert_eq!(counts.len(), 7);
+        assert!(
+            counts
+                .keys()
+                .all(|key| key.contains("objA") || key.contains("objB"))
+        );
+        // 条件付き一様: 各組み合わせが期待値 1000 の ±10% に収まる
+        let expected = TRIALS / 7;
+        for (key, count) in &counts {
+            assert!(
+                (expected * 9 / 10..=expected * 11 / 10).contains(count),
+                "{}: {} (expected around {})",
+                key,
+                count,
+                expected
+            );
+        }
+    }
+
+    /// 進行候補を引けない場合は条件なしの一様抽選にフォールバックする
+    #[test]
+    fn test_pick_items_with_retry_without_progression_candidates() {
+        let items: Vec<_> = ["objX", "objY", "objZ"]
+            .iter()
+            .map(|name| item(name))
+            .collect();
+        let mut rng = make_rng("test");
+        let mut pool = items_pool(items.iter().collect());
+        let picked = pool.pick_items_with_retry(&mut rng, 2, 0, 0, |_| false);
+        assert_eq!(picked.unwrap().0.len(), 2);
+        assert_eq!(pool.field_items.len(), 1);
     }
 }

--- a/src-tauri/src/randomizer/spoiler/mod.rs
+++ b/src-tauri/src/randomizer/spoiler/mod.rs
@@ -41,7 +41,6 @@ fn ptr_eq<'a>(a: SpotRef<'a>, b: &CheckpointRef<'a>) -> bool {
         (SpotRef::Seal(a), CheckpointRef::Seal(b)) => ptr::eq(a, b.spot),
         (SpotRef::Rom(a), CheckpointRef::Rom(b)) => ptr::eq(a, b.spot),
         (SpotRef::Talk(a), CheckpointRef::Talk(b)) => ptr::eq(a, b.spot),
-        (SpotRef::Shop(a), CheckpointRef::Shop(b)) => ptr::eq(a, b.spot),
         _ => false,
     }
 }

--- a/src-tauri/src/randomizer/spoiler/sphere/mod.rs
+++ b/src-tauri/src/randomizer/spoiler/sphere/mod.rs
@@ -1,9 +1,11 @@
 mod pre_sphere;
+mod progression;
 mod state;
 
 use std::{collections::HashSet, mem::take, ops::Deref};
 
 use pre_sphere::pre_sphere;
+use progression::{is_event_achievable, progression_flags};
 use rand::Rng;
 
 use crate::{
@@ -27,6 +29,14 @@ pub struct ShopItemDisplay<'a> {
     pub spot: &'a ShopSpot,
     pub idx: usize,
     pub name: &'a StrategyFlag,
+}
+
+fn item_shop_spot_count(spots: &Spots<'_>) -> usize {
+    spots
+        .shops
+        .iter()
+        .map(|shop| (!shop.name.is_consumable()) as usize)
+        .sum::<usize>()
 }
 
 fn explore<'a>(remaining_spots: &Spots<'a>, state: &State<'a>) -> (Spots<'a>, Spots<'a>) {
@@ -85,7 +95,7 @@ fn place_items<'a>(
                 let item = field_items.pop().unwrap();
                 sphere.push(CheckpointRef::from_field_spot_item(spot, item));
             }
-            SpotRef::Talk(_) | SpotRef::Shop(_) => unreachable!(),
+            SpotRef::Talk(_) => unreachable!(),
         });
     reachables.talk_spots.into_iter().for_each(|spot| {
         let item = talk_items.pop().unwrap();
@@ -128,13 +138,9 @@ fn place_items<'a>(
 }
 
 fn take_achieved<'a>(events: &mut Vec<&'a Event>, state: &State) -> Vec<&'a Event> {
-    let (achieved, unachieved) = take(events).into_iter().partition(|event| {
-        if let Some(region) = &event.region {
-            state.is_reachable(region, event.requirements.as_ref())
-        } else {
-            state.is_reachable_without_region(event.requirements.as_ref())
-        }
-    });
+    let (achieved, unachieved) = take(events)
+        .into_iter()
+        .partition(|event| is_event_achievable(state, event));
     *events = unachieved;
     achieved
 }
@@ -209,8 +215,15 @@ pub fn sphere<'a>(
         return None;
     }
 
-    let (field_items, talk_items, shop_items) =
-        items_pool.pick_items_randomly(rng, &reachables, &unreachables);
+    // 「進行候補を少なくとも1つ含む」という条件付きで一様に item 群を選ぶ
+    let progression = progression_flags(items_pool, state, &unreachables, all_regions);
+    let (field_items, talk_items, shop_items) = items_pool.pick_items_with_retry(
+        rng,
+        reachables.field_item_spots.len(),
+        reachables.talk_spots.len(),
+        item_shop_spot_count(&reachables),
+        |item| progression.contains(&item.name),
+    )?;
 
     let mut sphere = place_items(
         rng,

--- a/src-tauri/src/randomizer/spoiler/sphere/progression.rs
+++ b/src-tauri/src/randomizer/spoiler/sphere/progression.rs
@@ -46,12 +46,8 @@ impl RequirementNames {
         }
         for region in all_regions.iter() {
             result.add(region.access_rule());
-            for (_, access_rule) in region.exits().all_exits() {
-                let requirements = access_rule
-                    .clone()
-                    .try_into_any_of_all_requirements()
-                    .unwrap();
-                result.add(requirements.as_ref());
+            for exit in region.exits() {
+                result.add(exit.requirements.as_ref());
             }
         }
         result

--- a/src-tauri/src/randomizer/spoiler/sphere/progression.rs
+++ b/src-tauri/src/randomizer/spoiler/sphere/progression.rs
@@ -1,0 +1,153 @@
+use std::collections::HashSet;
+
+use crate::{
+    dataset::spot::AnyOfAllRequirements,
+    randomizer::{
+        spoiler::{items_pool::ItemsPool, regions::Regions, spots::Spots},
+        storage::{
+            Event,
+            item::{Item, StrategyFlag},
+        },
+    },
+};
+
+use super::state::State;
+
+pub fn is_event_achievable(state: &State, event: &Event) -> bool {
+    if let Some(region) = &event.region {
+        state.is_reachable(region, event.requirements.as_ref())
+    } else {
+        state.is_reachable_without_region(event.requirements.as_ref())
+    }
+}
+
+struct RequirementNames {
+    names: HashSet<String>,
+    includes_sacred_orb: bool,
+}
+
+impl RequirementNames {
+    fn collect(unreachables: &Spots, all_regions: &Regions) -> Self {
+        let mut result = Self {
+            names: HashSet::new(),
+            includes_sacred_orb: false,
+        };
+        for spot in &unreachables.field_item_spots {
+            result.add(spot.requirements());
+        }
+        for spot in &unreachables.talk_spots {
+            result.add(spot.requirements());
+        }
+        for shop in &unreachables.shops {
+            result.add(shop.spot.requirements());
+        }
+        for event in &unreachables.events {
+            result.add(event.requirements.as_ref());
+        }
+        for region in all_regions.iter() {
+            result.add(region.access_rule());
+            for (_, access_rule) in region.exits().all_exits() {
+                let requirements = access_rule
+                    .clone()
+                    .try_into_any_of_all_requirements()
+                    .unwrap();
+                result.add(requirements.as_ref());
+            }
+        }
+        result
+    }
+
+    fn add(&mut self, requirements: Option<&AnyOfAllRequirements>) {
+        let Some(any) = requirements else {
+            return;
+        };
+        for all in &any.0 {
+            for requirement in &all.0 {
+                if requirement.is_sacred_orb() {
+                    self.includes_sacred_orb = true;
+                } else {
+                    self.names.insert(requirement.get().to_owned());
+                }
+            }
+        }
+    }
+
+    fn contains(&self, name: &StrategyFlag) -> bool {
+        self.names.contains(name.get()) || self.includes_sacred_orb && name.is_sacred_orb()
+    }
+}
+
+/// state に item を単体で追加したとき、未到達の spot / event / region の
+/// いずれかが新たに到達可能になるか
+fn expands_reachability<'a>(
+    state: &State<'a>,
+    item: &'a Item,
+    unreachables: &Spots<'a>,
+    pending_events: &[&'a Event],
+    all_regions: &Regions<'a>,
+    baseline_region_count: usize,
+) -> bool {
+    let mut state = state.clone();
+    state.insert_flag(&item.name);
+    state.explore_regions(all_regions);
+    state.reachable_regions().count() > baseline_region_count
+        || unreachables
+            .field_item_spots
+            .iter()
+            .any(|x| state.is_reachable(x.region(), x.requirements()))
+        || unreachables
+            .talk_spots
+            .iter()
+            .any(|x| state.is_reachable(x.region(), x.requirements()))
+        || unreachables
+            .shops
+            .iter()
+            .any(|x| state.is_reachable(x.spot.region(), x.spot.requirements()))
+        || pending_events
+            .iter()
+            .any(|&event| is_event_achievable(&state, event))
+}
+
+/// items_pool のうち、現在の state に単体で追加すると未到達の
+/// spot / event / region を新たに到達可能にする item 名の集合
+pub fn progression_flags<'a>(
+    items_pool: &ItemsPool<'a>,
+    state: &State<'a>,
+    unreachables: &Spots<'a>,
+    all_regions: &Regions<'a>,
+) -> HashSet<&'a StrategyFlag> {
+    // どの requirement にも名前が現れない item は到達可能範囲を変えられないため、
+    // 事前に除外して到達可能性の再計算回数を減らす
+    let requirement_names = RequirementNames::collect(unreachables, all_regions);
+    let baseline_region_count = state.reachable_regions().count();
+    // 既に達成可能な event は「新たに」達成可能になるわけではないため除外する
+    let pending_events: Vec<_> = unreachables
+        .events
+        .iter()
+        .copied()
+        .filter(|event| !is_event_achievable(state, event))
+        .collect();
+
+    let mut visited = HashSet::new();
+    items_pool
+        .field_items
+        .as_slice()
+        .iter()
+        .chain(items_pool.talk_items.as_slice())
+        .chain(items_pool.shop_items.as_slice())
+        .copied()
+        .filter(|item| visited.insert(&item.name))
+        .filter(|item| requirement_names.contains(&item.name))
+        .filter(|&item| {
+            expands_reachability(
+                state,
+                item,
+                unreachables,
+                &pending_events,
+                all_regions,
+                baseline_region_count,
+            )
+        })
+        .map(|item| &item.name)
+        .collect()
+}

--- a/src-tauri/src/randomizer/spoiler/sphere/state.rs
+++ b/src-tauri/src/randomizer/spoiler/sphere/state.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Clone)]
 pub struct State<'a> {
     reachable_regions: Vec<&'a Region>,
-    strategy_flags: HashSet<&'a StrategyFlag>,
+    strategy_flags: HashSet<&'a str>,
     sacred_orb_count: u8,
 }
 
@@ -43,15 +43,10 @@ impl<'a> State<'a> {
         let Some(any) = requirements else {
             return true;
         };
-        let strategy_flag_strings: HashSet<_> = self
-            .strategy_flags
-            .iter()
-            .map(|x| x.get().to_owned())
-            .collect();
         any.0.iter().any(|all| {
             all.0.iter().all(|x| {
                 x.is_sacred_orb() && x.sacred_orb_count() <= self.sacred_orb_count
-                    || strategy_flag_strings.contains(x.get())
+                    || self.strategy_flags.contains(x.get())
             })
         })
     }
@@ -63,19 +58,15 @@ impl<'a> State<'a> {
     fn new_exit_names(&self, regions: &[&'a Region]) -> impl Iterator<Item = &'a RegionName> {
         regions
             .iter()
-            .flat_map(|x| x.exits().all_exits())
-            .filter(|&(region_name, access_rule)| {
-                let access_rule = access_rule
-                    .clone()
-                    .try_into_any_of_all_requirements()
-                    .unwrap();
-                self.is_reachable_without_region(access_rule.as_ref())
+            .flat_map(|x| x.exits())
+            .filter(|exit| {
+                self.is_reachable_without_region(exit.requirements.as_ref())
                     && self
                         .reachable_regions
                         .iter()
-                        .all(|x| x.name() != region_name)
+                        .all(|x| x.name() != &exit.target)
             })
-            .map(|(name, _)| name)
+            .map(|exit| &exit.target)
     }
 
     pub fn explore_regions(&mut self, all_regions: &Regions<'a>) {
@@ -123,7 +114,7 @@ impl<'a> State<'a> {
             if flag.is_sacred_orb() {
                 self.sacred_orb_count += 1;
             }
-            self.strategy_flags.insert(flag);
+            self.strategy_flags.insert(flag.get());
         }
     }
 }

--- a/src-tauri/src/randomizer/spoiler/sphere/state.rs
+++ b/src-tauri/src/randomizer/spoiler/sphere/state.rs
@@ -12,6 +12,7 @@ use crate::{
     },
 };
 
+#[derive(Clone)]
 pub struct State<'a> {
     reachable_regions: Vec<&'a Region>,
     strategy_flags: HashSet<&'a StrategyFlag>,

--- a/src-tauri/src/randomizer/spoiler/spots.rs
+++ b/src-tauri/src/randomizer/spoiler/spots.rs
@@ -1,7 +1,7 @@
 use crate::{
     dataset::spot::{
-        AnyOfAllRequirements, ChestSpot, MainWeaponSpot, Region, RomSpot, SealSpot, ShopSpot,
-        SubWeaponSpot, TalkSpot,
+        AnyOfAllRequirements, ChestSpot, MainWeaponSpot, Region, RomSpot, SealSpot, SubWeaponSpot,
+        TalkSpot,
     },
     randomizer::storage::{Event, Storage},
 };
@@ -16,7 +16,6 @@ pub enum SpotRef<'a> {
     Seal(&'a SealSpot),
     Rom(&'a RomSpot),
     Talk(&'a TalkSpot),
-    Shop(&'a ShopSpot),
 }
 
 impl SpotRef<'_> {
@@ -28,7 +27,6 @@ impl SpotRef<'_> {
             Self::Seal(x) => x.region(),
             Self::Rom(x) => x.region(),
             Self::Talk(x) => x.region(),
-            Self::Shop(x) => x.region(),
         }
     }
     pub fn requirements(&self) -> Option<&AnyOfAllRequirements> {
@@ -39,17 +37,8 @@ impl SpotRef<'_> {
             Self::Seal(x) => x.requirements(),
             Self::Rom(x) => Some(x.requirements()),
             Self::Talk(x) => x.requirements(),
-            Self::Shop(x) => x.requirements(),
         }
     }
-    // /// requirements に含まれているか
-    // pub fn is_related_to(&self, item: &Item) -> bool {
-    //     self.requirements().is_some_and(|reqs| {
-    //         reqs.0
-    //             .iter()
-    //             .any(|all| all.0.iter().any(|req| req == &item.name))
-    //     })
-    // }
 }
 
 #[derive(Clone, Debug)]

--- a/src-tauri/src/randomizer/spoiler_log.rs
+++ b/src-tauri/src/randomizer/spoiler_log.rs
@@ -108,7 +108,6 @@ impl<'a> CheckpointRef<'a> {
             SpotRef::Seal(spot) => Self::Seal(SealRef { spot, item }),
             SpotRef::Rom(spot) => Self::Rom(RomRef { spot, item }),
             SpotRef::Talk(spot) => Self::Talk(TalkRef { spot, item }),
-            SpotRef::Shop(_) => unreachable!(),
         }
     }
 

--- a/src-tauri/src/randomizer/storage/item.rs
+++ b/src-tauri/src/randomizer/storage/item.rs
@@ -1,6 +1,5 @@
 use crate::{
     dataset::spot::{RequirementFlag, SpotName},
-    randomizer::spoiler::spots::SpotRef,
     script::enums::{
         ChestItem, Equipment, FieldNumber, MainWeapon, Rom, Seal, ShopItem, SubWeapon, TalkItem,
     },
@@ -151,17 +150,5 @@ impl Item {
             | ItemSource::Chest((_, ChestItem::Rom(_)))
             | ItemSource::Talk(_) => true,
         }
-    }
-
-    /// 与えられたスポット一覧のいずれかから必要とされているか
-    pub fn is_required(&self, spots: &[&SpotRef]) -> bool {
-        spots
-            .iter()
-            .flat_map(|spot| spot.requirements())
-            .any(|reqs| {
-                reqs.0
-                    .iter()
-                    .any(|all| all.0.iter().any(|req| req == &self.name))
-            })
     }
 }


### PR DESCRIPTION
## 概要

sphere 内アイテム選択を「required item を1つ強制投入する」方式から、「一様に候補を選び、進行候補を含まない候補だけ棄却する」方式へ変更する(作業指示書に基づく)。

これにより「進行候補を少なくとも1つ含む」という条件付きで一様な分布に近づき、旧方式で進行候補同士の組み合わせ(例: AB)が過大に出やすかった偏りを解消する。

## 変更内容

- `move_one_required_item` による強制投入を廃止
- `ItemsPool::pick_items_randomly` は「毎回 pool を再シャッフルして必要数を取る」だけの純粋な一様抽選に変更
- `ItemsPool::pick_items_with_retry` を追加: 一時 pool(clone)上で抽選し、進行候補を1つも含まなければ棄却して再抽選。採用時のみ本体へ反映
- 進行候補判定 `sphere/progression.rs` を新規追加: 「現在の state にその item を単体で追加すると、未到達の spot / event / region のいずれかが新たに到達可能になる」ことを simulation で判定(requirements に名前が出るだけでは進行候補としない)。requirement に名前が現れない item は事前に除外して到達可能性の再計算を削減。sacredOrb は個数条件のため特別扱い
- 進行候補をそもそも引けない場合(最終 sphere、A+B が揃って初めて進行するケース等)は無条件の一様抽選にフォールバック(旧実装の「required item が見つからなければ素通し」と同等の挙動)
- 構築箇所がなくなった `SpotRef::Shop` variant を削除
- 出力が変わるためハッシュ固定テストの期待値を更新

## 作業指示書からの意図的な差分

- 棄却リトライのループは `sphere/mod.rs` ではなく `ItemsPool::pick_items_with_retry` に置き、進行判定だけをクロージャで注入する形にした。`ItemsPool` を `State` 非依存に保ったまま分布の単体テストを書けるため
- 進行候補が引けない場合は `None` ではなく無条件抽選にフォールバックする。ここで `None` を返すと正当なシード(複合依存)まで失敗扱いになるため

## テスト

- `test_pick_items_with_retry_is_conditionally_uniform`: 進行候補 A, B と非進行候補 x, y, z から2個選ぶとき、7通り(AB, Ax, Ay, Az, Bx, By, Bz)がすべて期待値±10%内で均等になることを確認(旧方式では AB が約1.75倍)
- `test_pick_items_with_retry_without_progression_candidates`: フォールバック経路の確認
- `test_shuffle_multi_patterns`(100シード・glitchあり): 全シードで生成成功。release ビルドで約85秒(約0.8秒/シード)
- `cargo clippy --all-targets` 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4Cv2nj8WYD7caAVCEpbPF